### PR TITLE
Fix issue with extension overflowing topbar

### DIFF
--- a/stylesheet.css
+++ b/stylesheet.css
@@ -47,7 +47,7 @@
 .gsp-indicator {
     background-color: #1e1e1e;
     border-radius: 2px;
-    height: 28px;
+    height: 100%;
     width: 8px;
 
     grid-color: #575757;


### PR DESCRIPTION
Turns 
![Screenshot from 2019-03-16 15-23-41](https://user-images.githubusercontent.com/4013804/54479931-60571e00-4801-11e9-956a-4f0a21b76623.png) 
into
![Screenshot from 2019-03-16 15-34-55](https://user-images.githubusercontent.com/4013804/54479933-6816c280-4801-11e9-8a3e-bf132fa468eb.png)

It looks kind of small in my 14" FHD, but I didn't like how it looked playing with paddings.
