### PR TITLE
fix #16

### DIFF
--- a/stylesheet.css
+++ b/stylesheet.css
@@ -47,7 +47,7 @@
 .gsp-indicator {
     background-color: #1e1e1e;
     border-radius: 2px;
-    height: 28px;
+    height: 16px;
     width: 8px;
 
     grid-color: #575757;


### PR DESCRIPTION
Reduce the height so that it doesn't exceed the top bar in gnome 3.32.

Later edit: Only after making the pull request I noticed the other solution in #17 which seems nicer if the top bar is modified by other extensions.