### PR TITLE
Adjust height of container for gnome-shell@3.32.x

### DIFF
--- a/stylesheet.css
+++ b/stylesheet.css
@@ -5,6 +5,8 @@
     padding-right: 4px;
     padding-bottom: 4px;
     padding-top: 4px;
+
+    height: 100%;
 }
 
 .gsp-graph-area {


### PR DESCRIPTION
This commit fixes the height of the panel indicators.

The height of the panel in gnome-shell was changed causing the bars to stick out below. With this fix they now fit in the panel again