### PR TITLE
Fix for maximum value in network chart inbound removed by last commit

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -178,7 +178,7 @@ HorizontalGraph.prototype = {
         let max = 0;
 
         this.renderStats.map(Lang.bind(this, function(k){
-            max = this.stats[k].max;
+            max = Math.max(max, this.stats[k].max);
         }));
 
         if (max < this.max) {


### PR DESCRIPTION
Hi!
This fix for maximum value in network chart inbound removed by last commit on 18 Nov 2023.
This bug was fixed by commit on 11 Jul 2022, but returned with last commit.